### PR TITLE
Added a minimal example that blinks the LED and prints.

### DIFF
--- a/examples/hello_world/.gitignore
+++ b/examples/hello_world/.gitignore
@@ -1,0 +1,3 @@
+.pio
+.vscode
+include/pico/config_autogen.h

--- a/examples/hello_world/platformio.ini
+++ b/examples/hello_world/platformio.ini
@@ -1,0 +1,36 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:raspberry-pi-pico]
+; Fixing to Wizio 1.08 which is known to work as of June 2021.
+platform = https://github.com/Wiz-IO/wizio-pico.git#3250e0732cf4c0ff72d4c689317fc7481a34b612
+platform_packages =
+	framework-wizio-pico@https://github.com/Wiz-IO/framework-wizio-pico.git#6f1e42f31a10441688c67588d98ffc9473a2470d
+board = raspberry-pi-pico
+; 'baremetal' is the Pico C++ SDK experience.
+framework = baremetal
+; As for Juen 2021, this works on Windows, using a second
+; Pico with the 'picoprobe' firmware as a hardware debugger
+; to set breakpoints, single steps, examing variables, etc.
+upload_protocol = picoprobe
+debug_tool = picoprobe
+; Adjust to the actual port used by the Pico on your system.
+monitor_port = COM[2345]
+; This enables Pico's int64 printf.
+board_build.nano = disable
+; The -I options allows to jump to SDK declarations and definitions.
+build_flags = 
+	-I "$PROJECT_CORE_DIR/packages/framework-wizio-pico/SDK111/hardware"
+	-I "$PROJECT_CORE_DIR/packages/framework-wizio-pico/SDK/pico"
+	-D PICO_STDIO_USB
+
+;monitor_speed = 115200
+
+;lib_deps = 

--- a/examples/hello_world/platformio.ini
+++ b/examples/hello_world/platformio.ini
@@ -9,10 +9,13 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:raspberry-pi-pico]
-; Fixing to Wizio 1.08 which is known to work as of June 2021.
-platform = https://github.com/Wiz-IO/wizio-pico.git#3250e0732cf4c0ff72d4c689317fc7481a34b612
+; The specification of the platform and platform_packages below causes
+; automatic loading of the latest version. To pin a specific version
+; see the platformio discussion at 
+; https://community.platformio.org/t/how-to-specify-desired-version-of-an-installed-framework/21970/8
+platform = https://github.com/Wiz-IO/wizio-pico.git
 platform_packages =
-	framework-wizio-pico@https://github.com/Wiz-IO/framework-wizio-pico.git#6f1e42f31a10441688c67588d98ffc9473a2470d
+	framework-wizio-pico@https://github.com/Wiz-IO/framework-wizio-pico.git
 board = raspberry-pi-pico
 ; 'baremetal' is the Pico C++ SDK experience.
 framework = baremetal
@@ -22,15 +25,14 @@ framework = baremetal
 upload_protocol = picoprobe
 debug_tool = picoprobe
 ; Adjust to the actual port used by the Pico on your system.
-monitor_port = COM[2345]
+monitor_port = COM4
 ; This enables Pico's int64 printf.
 board_build.nano = disable
 ; The -I options allows to jump to SDK declarations and definitions.
 build_flags = 
 	-I "$PROJECT_CORE_DIR/packages/framework-wizio-pico/SDK111/hardware"
 	-I "$PROJECT_CORE_DIR/packages/framework-wizio-pico/SDK/pico"
-	-D PICO_STDIO_USB
-
+	-D LIB_PICO_STDIO_USB
+	
 ;monitor_speed = 115200
-
 ;lib_deps = 

--- a/examples/hello_world/platformio.ini
+++ b/examples/hello_world/platformio.ini
@@ -25,6 +25,8 @@ framework = baremetal
 upload_protocol = picoprobe
 debug_tool = picoprobe
 ; Adjust to the actual port used by the Pico on your system.
+; This must be an exact port name. As of June 2021, monitor_port
+; glob expressions are not supported here.
 monitor_port = COM4
 ; This enables Pico's int64 printf.
 board_build.nano = disable

--- a/examples/hello_world/src/main.cpp
+++ b/examples/hello_world/src/main.cpp
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include "pico/stdlib.h"
+#include "pico.h"
+
+void setup() {
+  stdio_init_all();
+  gpio_init(PICO_DEFAULT_LED_PIN);
+  gpio_set_dir(PICO_DEFAULT_LED_PIN, true);
+}
+
+void loop() {
+  gpio_put(PICO_DEFAULT_LED_PIN, true);
+  sleep_ms(500);
+  gpio_put(PICO_DEFAULT_LED_PIN, false);
+  sleep_ms(500);
+  printf("Hello world\n");
+}
+
+int main() {
+  setup();
+  for (;;) {
+    loop();
+  }
+}


### PR DESCRIPTION
This is an example of a minimal project that uses the 'baremetal' framework. Because it's not clear if the latest version of baremetal supports printf to USB/CDC, the example currently is set to use the older SDK. 