### PR TITLE
Added support to 'upload_port' option on platformio.ini

### DIFF
--- a/builder/frameworks/uf2conv.py
+++ b/builder/frameworks/uf2conv.py
@@ -366,10 +366,6 @@ def dev_uploader(target, source, env):
     time.sleep(.1)
     write_file(uf2_name, outbuf)  # write uf2 to build folder
 
-    print("===================")
-    print(env)
-    print("===================")
-
     if drive:
         if has_info(drive):
             print("Flashing %s (%s)" % (drive, board_id(drive)))

--- a/builder/frameworks/uf2conv.py
+++ b/builder/frameworks/uf2conv.py
@@ -11,47 +11,48 @@ import serial
 from os.path import join
 from platform import system
 
-UF2_MAGIC_START0 = 0x0A324655 # "UF2\n"
-UF2_MAGIC_START1 = 0x9E5D5157 # Randomly selected
-UF2_MAGIC_END    = 0x0AB16F30 # Ditto
+UF2_MAGIC_START0 = 0x0A324655  # "UF2\n"
+UF2_MAGIC_START1 = 0x9E5D5157  # Randomly selected
+UF2_MAGIC_END = 0x0AB16F30  # Ditto
 
 families = {
-    'SAMD21'        : 0x68ed2b88,
-    'SAML21'        : 0x1851780a,
-    'SAMD51'        : 0x55114460,
-    'NRF52'         : 0x1b57745f,
-    'STM32F0'       : 0x647824b6,
-    'STM32F1'       : 0x5ee21072,
-    'STM32F2'       : 0x5d1a0a2e,
-    'STM32F3'       : 0x6b846188,
-    'STM32F4'       : 0x57755a57,
-    'STM32F7'       : 0x53b80f00,
-    'STM32G0'       : 0x300f5633,
-    'STM32G4'       : 0x4c71240a,
-    'STM32H7'       : 0x6db66082,
-    'STM32L0'       : 0x202e3a91,
-    'STM32L1'       : 0x1e1f432d,
-    'STM32L4'       : 0x00ff6919,
-    'STM32L5'       : 0x04240bdf,
-    'STM32WB'       : 0x70d16653,
-    'STM32WL'       : 0x21460ff0,
-    'ATMEGA32'      : 0x16573617,
-    'MIMXRT10XX'    : 0x4FB2D5BD,
-    'LPC55'         : 0x2abc77ec,
-    'GD32F350'      : 0x31D228C6,
-    'ESP32S2'       : 0xbfdd4eee,
-    'RP2040'        : 0xe48bff56
+    'SAMD21': 0x68ed2b88,
+    'SAML21': 0x1851780a,
+    'SAMD51': 0x55114460,
+    'NRF52': 0x1b57745f,
+    'STM32F0': 0x647824b6,
+    'STM32F1': 0x5ee21072,
+    'STM32F2': 0x5d1a0a2e,
+    'STM32F3': 0x6b846188,
+    'STM32F4': 0x57755a57,
+    'STM32F7': 0x53b80f00,
+    'STM32G0': 0x300f5633,
+    'STM32G4': 0x4c71240a,
+    'STM32H7': 0x6db66082,
+    'STM32L0': 0x202e3a91,
+    'STM32L1': 0x1e1f432d,
+    'STM32L4': 0x00ff6919,
+    'STM32L5': 0x04240bdf,
+    'STM32WB': 0x70d16653,
+    'STM32WL': 0x21460ff0,
+    'ATMEGA32': 0x16573617,
+    'MIMXRT10XX': 0x4FB2D5BD,
+    'LPC55': 0x2abc77ec,
+    'GD32F350': 0x31D228C6,
+    'ESP32S2': 0xbfdd4eee,
+    'RP2040': 0xe48bff56
 }
 
 INFO_FILE = "/INFO_UF2.TXT"
 
-appstartaddr    = 0x10000000 # pico flash
-familyid        = 0xe48bff56 # pico selected
+appstartaddr = 0x10000000  # pico flash
+familyid = 0xe48bff56  # pico selected
 
 
 def is_uf2(buf):
     w = struct.unpack("<II", buf[0:8])
     return w[0] == UF2_MAGIC_START0 and w[1] == UF2_MAGIC_START1
+
 
 def is_hex(buf):
     try:
@@ -61,6 +62,7 @@ def is_hex(buf):
     if w[0] == ':' and re.match(b"^[:0-9a-fA-F\r\n]+$", buf):
         return True
     return False
+
 
 def convert_from_uf2(buf):
     global appstartaddr
@@ -94,9 +96,10 @@ def convert_from_uf2(buf):
         while padding > 0:
             padding -= 4
             outp += b"\x00\x00\x00\x00"
-        outp.append(block[32 : 32 + datalen])
+        outp.append(block[32: 32 + datalen])
         curraddr = newaddr + datalen
     return b"".join(outp)
+
 
 def convert_to_carray(file_content):
     outp = "const unsigned long bindata_len = %d;\n" % len(file_content)
@@ -107,6 +110,7 @@ def convert_to_carray(file_content):
         outp += "0x%02x, " % file_content[i]
     outp += "\n};\n"
     return bytes(outp, "utf-8")
+
 
 def convert_to_uf2(file_content):
     global familyid
@@ -123,14 +127,15 @@ def convert_to_uf2(file_content):
         if familyid:
             flags |= 0x2000
         hd = struct.pack(b"<IIIIIIII",
-            UF2_MAGIC_START0, UF2_MAGIC_START1,
-            flags, ptr + appstartaddr, 256, blockno, numblocks, familyid)
+                         UF2_MAGIC_START0, UF2_MAGIC_START1,
+                         flags, ptr + appstartaddr, 256, blockno, numblocks, familyid)
         while len(chunk) < 256:
             chunk += b"\x00"
         block = hd + chunk + datapadding + struct.pack(b"<I", UF2_MAGIC_END)
         assert len(block) == 512
         outp.append(block)
     return b"".join(outp)
+
 
 class Block:
     def __init__(self, addr):
@@ -143,13 +148,14 @@ class Block:
         if familyid:
             flags |= 0x2000
         hd = struct.pack("<IIIIIIII",
-            UF2_MAGIC_START0, UF2_MAGIC_START1,
-            flags, self.addr, 256, blockno, numblocks, familyid)
+                         UF2_MAGIC_START0, UF2_MAGIC_START1,
+                         flags, self.addr, 256, blockno, numblocks, familyid)
         hd += self.bytes[0:256]
         while len(hd) < 512 - 4:
             hd += b"\x00"
         hd += struct.pack("<I", UF2_MAGIC_END)
         return hd
+
 
 def convert_from_hex_to_uf2(buf):
     global appstartaddr
@@ -191,13 +197,23 @@ def convert_from_hex_to_uf2(buf):
         resfile += blocks[i].encode(i, numblocks)
     return resfile
 
+
 def to_str(b):
     return b.decode("utf-8")
+
+
+def has_info(d):
+    try:
+        return os.path.isfile(d + INFO_FILE)
+    except:
+        return False
+
 
 def get_drives():
     drives = []
     if sys.platform == "win32":
-        r = subprocess.check_output(["wmic", "PATH", "Win32_LogicalDisk", "get", "DeviceID,", "VolumeName,", "FileSystem,", "DriveType"])
+        r = subprocess.check_output(["wmic", "PATH", "Win32_LogicalDisk",
+                                    "get", "DeviceID,", "VolumeName,", "FileSystem,", "DriveType"])
         for line in to_str(r).split('\n'):
             words = re.split('\s+', line)
             if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
@@ -213,12 +229,11 @@ def get_drives():
         for d in os.listdir(rootpath):
             drives.append(os.path.join(rootpath, d))
 
-
-    def has_info(d):
-        try:
-            return os.path.isfile(d + INFO_FILE)
-        except:
-            return False
+    # def has_info(d):
+    #     try:
+    #         return os.path.isfile(d + INFO_FILE)
+    #     except:
+    #         return False
 
     return list(filter(has_info, drives))
 
@@ -242,19 +257,30 @@ def write_file(name, buf):
 
 def main():
     global appstartaddr, familyid
+
     def error(msg):
         print(msg)
         sys.exit(1)
-    parser = argparse.ArgumentParser(description='Convert to UF2 or flash directly.')
-    parser.add_argument('input', metavar='INPUT', type=str, nargs='?', help='input file (HEX, BIN or UF2)')
-    parser.add_argument('-b' , '--base', dest='base', type=str, default="0x10000000", help='set base address of application for BIN format (default: 0x10000000)')
-    parser.add_argument('-o' , '--output', metavar="FILE", dest='output', type=str, help='write output to named file; defaults to "flash.uf2" or "flash.bin" where sensible')
-    parser.add_argument('-d' , '--device', dest="device_path", help='select a device path to flash')
-    parser.add_argument('-l' , '--list', action='store_true', help='list connected devices')
-    parser.add_argument('-c' , '--convert', action='store_true', help='do not flash, just convert')
-    parser.add_argument('-D' , '--deploy', action='store_true', help='just flash, do not convert')
-    parser.add_argument('-f' , '--family', dest='family', type=str, default="0x0", help='specify familyID - number or name (default: 0x0)')
-    parser.add_argument('-C' , '--carray', action='store_true', help='convert binary file to a C array, not UF2')
+    parser = argparse.ArgumentParser(
+        description='Convert to UF2 or flash directly.')
+    parser.add_argument('input', metavar='INPUT', type=str,
+                        nargs='?', help='input file (HEX, BIN or UF2)')
+    parser.add_argument('-b', '--base', dest='base', type=str, default="0x10000000",
+                        help='set base address of application for BIN format (default: 0x10000000)')
+    parser.add_argument('-o', '--output', metavar="FILE", dest='output', type=str,
+                        help='write output to named file; defaults to "flash.uf2" or "flash.bin" where sensible')
+    parser.add_argument('-d', '--device', dest="device_path",
+                        help='select a device path to flash')
+    parser.add_argument('-l', '--list', action='store_true',
+                        help='list connected devices')
+    parser.add_argument('-c', '--convert', action='store_true',
+                        help='do not flash, just convert')
+    parser.add_argument('-D', '--deploy', action='store_true',
+                        help='just flash, do not convert')
+    parser.add_argument('-f', '--family', dest='family', type=str, default="0x0",
+                        help='specify familyID - number or name (default: 0x0)')
+    parser.add_argument('-C', '--carray', action='store_true',
+                        help='convert binary file to a C array, not UF2')
     args = parser.parse_args()
     appstartaddr = int(args.base, 0)
 
@@ -264,7 +290,8 @@ def main():
         try:
             familyid = int(args.family, 0)
         except ValueError:
-            error("Family ID needs to be a number or one of: " + ", ".join(families.keys()))
+            error("Family ID needs to be a number or one of: " +
+                  ", ".join(families.keys()))
 
     if args.list:
         list_drives()
@@ -287,7 +314,8 @@ def main():
             ext = "h"
         else:
             outbuf = convert_to_uf2(inpbuf)
-        print("Converting to %s, output size: %d, start address: 0x%x" % (ext, len(outbuf), appstartaddr))
+        print("Converting to %s, output size: %d, start address: 0x%x" %
+              (ext, len(outbuf), appstartaddr))
         if args.convert or ext != "uf2":
             drives = []
             if args.output == None:
@@ -318,22 +346,41 @@ def dev_uploader(target, source, env):
     global appstartaddr
     appstartaddr = int(env.address, 0)
     bin_name = join(env.get("BUILD_DIR"), env.get("PROGNAME"))+'.bin'
+    elf_name = join(env.get("BUILD_DIR"), env.get("PROGNAME"))+'.elf'
     uf2_name = join(env.get("BUILD_DIR"), env.get("PROGNAME"))+'.uf2'
     drive = env.get("UPLOAD_PORT")
     if None != env.GetProjectOption("monitor_port"):
-        try: # reset usb stdio
-            usb = serial.Serial( env.GetProjectOption("monitor_port"), 1200)
+        try:  # reset usb stdio
+            usb = serial.Serial(env.GetProjectOption("monitor_port"), 1200)
             time.sleep(0.1)
             usb.close()
         except:
             pass
-        time.sleep(1.0) # Windows - AutoPlay
-        if 'Windows' not in system(): time.sleep(1.0)
-    print( "  Converting to UF2 ( 0x%x )" % (appstartaddr) )
-    with open( bin_name, mode='rb' ) as f: inpbuf = f.read()
+        time.sleep(1.0)  # Windows - AutoPlay
+        if 'Windows' not in system():
+            time.sleep(1.0)
+    print("  Converting to UF2 ( 0x%x )" % (appstartaddr))
+    with open(bin_name, mode='rb') as f:
+        inpbuf = f.read()
     outbuf = convert_to_uf2(inpbuf)
     time.sleep(.1)
-    write_file(uf2_name, outbuf) # write uf2 to build folder
+    write_file(uf2_name, outbuf)  # write uf2 to build folder
+
+    print("===================")
+    print(env)
+    print("===================")
+
+    if drive:
+        if has_info(drive):
+            print("Flashing %s (%s)" % (drive, board_id(drive)))
+            write_file(drive + '/' + env.get("PROGNAME") +
+                       '.uf2', outbuf)  # write ufs to pico
+            return
+        else:
+            print(
+                "Pico USB drive not found on provided \"upload_port\". " +
+                "Falling back to auto port detection...")
+
     drives = get_drives()
     if len(drives) == 0:
         #raise RuntimeError("Pico USB drive not found.")
@@ -343,5 +390,6 @@ def dev_uploader(target, source, env):
         return
     for d in drives:
         print("Flashing %s (%s)" % (d, board_id(d)))
-        write_file(d +'/'+ env.get("PROGNAME")+'.uf2', outbuf) # write ufs to pico
-    time.sleep(1.0) # usb-serial driver up
+        write_file(d + '/' + env.get("PROGNAME") +
+                   '.uf2', outbuf)  # write ufs to pico
+    time.sleep(1.0)  # usb-serial driver up


### PR DESCRIPTION
The upload_protocol setting was unused. I added a minor check at the end of the file before using the auto folder detection function. If it fails it graciously falls back to the auto drive detection procedure.
The formater changed a phew more lines that I'd liked to.

the actual change is this:
`
    # Uploads uf2 to configured 'upload_port'
    if drive:
        if has_info(drive):
            print("Flashing %s (%s)" % (drive, board_id(drive)))
            write_file(drive + '/' + env.get("PROGNAME") +
                       '.uf2', outbuf)  # write ufs to pico
            return
        else:
            print(
                "Pico USB drive not found on provided \"upload_port\". " +
                "Falling back to auto port detection...")
`

in dev_uploader just before calling get_drives()